### PR TITLE
resolvedRefs condition additional checks

### DIFF
--- a/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
+++ b/conformance/tests/httproute-invalid-cross-namespace-parent-ref.go
@@ -38,6 +38,7 @@ var HTTPRouteInvalidCrossNamespaceParentRef = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
 		routeNN := types.NamespacedName{Name: "invalid-cross-namespace-parent-ref", Namespace: "gateway-conformance-web-backend"}
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		// When running conformance tests, implementations are expected to have visibility across all namespaces, and
 		// must be setting this condition on routes that are not allowed. However, outside of conformance testing,

--- a/conformance/tests/httproute-invalid-cross-namespace-parent-ref.yaml
+++ b/conformance/tests/httproute-invalid-cross-namespace-parent-ref.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   parentRefs:
   - name: same-namespace
+    namespace: gateway-conformance-infra
   rules:
   - backendRefs:
     - name: web-backend

--- a/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go
+++ b/conformance/tests/httproute-invalid-parentref-not-matching-listener-port.go
@@ -39,16 +39,17 @@ var HTTPRouteInvalidParentRefNotMatchingListenerPort = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		routeNN := types.NamespacedName{Name: "httproute-listener-not-matching-route-port", Namespace: "gateway-conformance-infra"}
 		gwNN := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
+		kubernetes.HTTPRouteMustHaveResolvedRefsConditionsTrue(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN)
 
 		// The Route must have an Accepted Condition with a NoMatchingParent Reason.
 		t.Run("HTTPRoute with no matching port in ParentRef has an Accepted Condition with status False and Reason NoMatchingParent", func(t *testing.T) {
-			resolvedRefsCond := metav1.Condition{
+			acceptedCond := metav1.Condition{
 				Type:   string(v1beta1.RouteConditionAccepted),
 				Status: metav1.ConditionFalse,
 				Reason: string(v1beta1.RouteReasonNoMatchingParent),
 			}
 
-			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, resolvedRefsCond)
+			kubernetes.HTTPRouteMustHaveCondition(t, suite.Client, suite.TimeoutConfig, routeNN, gwNN, acceptedCond)
 		})
 
 		t.Run("Route should not have Parents accepted in status", func(t *testing.T) {


### PR DESCRIPTION
The ResolvedRefs condition is checked in the
HTTPRouteInvalidCrossNamespaceParentRef  and HTTPRouteInvalidParentRefNotMatchingListenerPort tests as well.
Besides, the namespace of the parentRefs has been added in the invalid-cross-namespace-parent-ref HTTPRoute.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API, please read our
   developer guide (https://gateway-api.sigs.k8s.io/devguide/)
   and our community page (https://gateway-api.sigs.k8s.io/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
